### PR TITLE
add mdev rule to run btattach for Cypress BT adapter

### DIFF
--- a/recipes-bsp/startup-scripts/files/cypress_bluetooth.sh
+++ b/recipes-bsp/startup-scripts/files/cypress_bluetooth.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-attach_cypress_bt()
-{
-    btattach -P h4 -B /dev/ttyUSB0 &
-}
-
 # bluetoothSensorTag needs to be able to open a socket to dbus-daemon and vice
 # versa. Since dbus-daemon runs under smack label "_" it's necessary to allow
 # all processes running with label _ to access the bluetoothSensorTag
@@ -19,7 +14,6 @@ sensortag_smack_workaround()
 
 do_start()
 {
-    attach_cypress_bt
     sensortag_smack_workaround
 }
 

--- a/recipes-core/initscripts/files/mdev.conf
+++ b/recipes-core/initscripts/files/mdev.conf
@@ -1,0 +1,41 @@
+console 0:0 0600
+ttyHS0 0:20 660
+ttyHSL0 0:20 660
+ttyHSL1 0:0 600
+cpu_dma_latency 0:0 0660
+fb0:0 44 0660
+full 0:0 0666
+initctl 0:0 0600
+ircomm[0-9].* 0:20 0660
+kmem 0:15 0640
+kmsg 0:0 0660
+log 0:0 0666
+loop[0-9].* 0:6 0640
+mem 0:15 0640
+network_latency 0:0 0660
+network_throughput 0:0 0660
+null 0:0 0666
+port 0:15 0640
+ptmx 0:5 0666
+ram[0-9].* 0:6 0640
+random 0:0 0666
+sda 0:6 0640
+tty 0:5 0666
+ttyUSB[0-9]+ 0:0 0620 */etc/mdev/ttyUSB.sh
+tty.* 0:0 0620
+urandom 0:0 0666
+usbdev.* 0:0 0660 */etc/mdev/usb.sh
+vcs.* 0:5 0660
+zero 0:0 0666
+
+snd/pcm.* 0:0 0660
+snd/control.* 0:0 0660
+snd/timer 0:0 0660
+snd/seq 0:0 0660
+snd/mini.* 0:00 0660
+
+input/event.* 0:0 0660 @/etc/mdev/find-touchscreen.sh
+input/mice 0:0 0660
+input/mouse.* 0:0 0660
+
+tun[0-9]* 0:0 0660 =net/

--- a/recipes-core/initscripts/files/mdev/ttyUSB.sh
+++ b/recipes-core/initscripts/files/mdev/ttyUSB.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Look for ttyUSB devices which match the known location of the USB to UART
+# adapter connected to the Cypress Bluetooth on the mangOH Yellow. When such a
+# device is identified, either spawn or kill btattach depending on whether the
+# UART is being added or removed respectively.
+if [ $DEVNAME ] && [ $DEVPATH == "/devices/7c00000.hsic_host/usb1/1-1/1-1.2/1-1.2:1.0/$DEVNAME/tty/$DEVNAME" ]
+then
+    PIDFILE="/var/run/btattach.$DEVNAME.pid"
+    if [ $ACTION == 'add' ]
+    then
+        echo "Running btattach on /dev/$DEVNAME"
+        btattach -P h4 -B /dev/$DEVNAME &
+        echo -n $! > $PIDFILE
+    elif [ $ACTION == 'remove' ]
+    then
+        if [ -f $PIDFILE ]
+        then
+            echo "Killing btattach for /dev/$DEVNAME"
+            PID=`cat $PIDFILE`
+            kill $PID
+            if [ $? -ne 0 ]
+            then
+                kill -9 $PID
+            fi
+            rm -f $PIDFILE
+        fi
+    fi
+fi

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -1,1 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://mdev/ttyUSB.sh"
+
+do_install_append() {
+    # Install an mdev rule for running btattach on the UART connected to the
+    # Cypress Bluetooth adapter on mangOH Yellow
+    install -m 0755 ${WORKDIR}/mdev/ttyUSB.sh -D ${D}${sysconfdir}/mdev/ttyUSB.sh
+}


### PR DESCRIPTION
Run btattach from mdev instead of in the cypress_bluetooth.sh init
script. This has the advantage of working even if the UART comes up as
/dev/ttyUSB1 instead of /dev/ttyUSB0.